### PR TITLE
Update EV compute logic

### DIFF
--- a/application/gui/views/main_view.c
+++ b/application/gui/views/main_view.c
@@ -261,56 +261,47 @@ void main_view_set_lux(MainView* main_view, float val) {
 
 void main_view_reset_lux(MainView* main_view) {
     furi_assert(main_view);
-    with_view_model(
-        main_view->view, MainViewModel * model, { model->peakLux = 0; }, true);
+    with_view_model(main_view->view, MainViewModel * model, { model->peakLux = 0; }, true);
 }
 
 void main_view_set_EV(MainView* main_view, float val) {
     furi_assert(main_view);
-    with_view_model(
-        main_view->view, MainViewModel * model, { model->EV = val; }, true);
+    with_view_model(main_view->view, MainViewModel * model, { model->EV = val; }, true);
 }
 
 void main_view_set_response(MainView* main_view, bool val) {
     furi_assert(main_view);
-    with_view_model(
-        main_view->view, MainViewModel * model, { model->response = val; }, true);
+    with_view_model(main_view->view, MainViewModel * model, { model->response = val; }, true);
 }
 
 void main_view_set_iso(MainView* main_view, int iso) {
     furi_assert(main_view);
-    with_view_model(
-        main_view->view, MainViewModel * model, { model->iso = iso; }, true);
+    with_view_model(main_view->view, MainViewModel * model, { model->iso = iso; }, true);
 }
 
 void main_view_set_nd(MainView* main_view, int nd) {
     furi_assert(main_view);
-    with_view_model(
-        main_view->view, MainViewModel * model, { model->nd = nd; }, true);
+    with_view_model(main_view->view, MainViewModel * model, { model->nd = nd; }, true);
 }
 
 void main_view_set_aperture(MainView* main_view, int aperture) {
     furi_assert(main_view);
-    with_view_model(
-        main_view->view, MainViewModel * model, { model->aperture = aperture; }, true);
+    with_view_model(main_view->view, MainViewModel * model, { model->aperture = aperture; }, true);
 }
 
 void main_view_set_speed(MainView* main_view, int speed) {
     furi_assert(main_view);
-    with_view_model(
-        main_view->view, MainViewModel * model, { model->speed = speed; }, true);
+    with_view_model(main_view->view, MainViewModel * model, { model->speed = speed; }, true);
 }
 
 void main_view_set_dome(MainView* main_view, bool dome) {
     furi_assert(main_view);
-    with_view_model(
-        main_view->view, MainViewModel * model, { model->dome = dome; }, true);
+    with_view_model(main_view->view, MainViewModel * model, { model->dome = dome; }, true);
 }
 
 void main_view_set_lux_only(MainView* main_view, bool lux_only) {
     furi_assert(main_view);
-    with_view_model(
-        main_view->view, MainViewModel * model, { model->lux_only = lux_only; }, true);
+    with_view_model(main_view->view, MainViewModel * model, { model->lux_only = lux_only; }, true);
 }
 
 void main_view_set_measurement_resolution(MainView* main_view, int measurement_resolution) {
@@ -337,8 +328,7 @@ void main_view_set_sensor_type(MainView* main_view, int sensor_type) {
 bool main_view_get_dome(MainView* main_view) {
     furi_assert(main_view);
     bool val = false;
-    with_view_model(
-        main_view->view, MainViewModel * model, { val = model->dome; }, true);
+    with_view_model(main_view->view, MainViewModel * model, { val = model->dome; }, true);
     return val;
 }
 
@@ -373,7 +363,7 @@ void draw_top_row(Canvas* canvas, MainViewModel* context) {
         canvas_draw_line(canvas, 0, 10, 128, 10);
 
         canvas_set_font(canvas, FontPrimary);
-        // metering mode A – ambient, F – flash
+        // metering mode A ÔÇô ambient, F ÔÇô flash
         // canvas_draw_str_aligned(canvas, 1, 1, AlignLeft, AlignTop, "A");
 
         snprintf(str, sizeof(str), "ISO: %d", iso_numbers[model->iso]);

--- a/application/gui/views/main_view.c
+++ b/application/gui/views/main_view.c
@@ -8,7 +8,7 @@
 
 #define WORKER_TAG "Main View"
 
-static const int iso_numbers[] = {
+const int iso_numbers[] = {
     [ISO_6] = 6,
     [ISO_12] = 12,
     [ISO_25] = 25,

--- a/application/gui/views/main_view.h
+++ b/application/gui/views/main_view.h
@@ -9,11 +9,11 @@
    with reasonable resolution in 1-10k range
    on 20px of screen height  */
 #define LUX_HISTORGRAM_LOGBASE 1.4
-#define LUX_HISTORGRAM_BOTTOM 64 + 12
+#define LUX_HISTORGRAM_BOTTOM  64 + 12
 
 /* 40 pixels between 45th and 85th
    between left and right button labels */
-#define LUX_HISTORGRAM_LEFT 45
+#define LUX_HISTORGRAM_LEFT   45
 #define LUX_HISTORGRAM_LENGTH 40
 
 typedef struct MainView MainView;

--- a/application/lightmeter.c
+++ b/application/lightmeter.c
@@ -245,7 +245,7 @@ void lightmeter_app_i2c_callback(LightMeterApp* context) {
     }
 
     if(main_view_get_dome(app->main_view)) lux *= DOME_COEFFICIENT;
-    EV = lux2ev(lux);
+    EV = lux2ev(lux, app->config->iso);
 
     main_view_set_lux(app->main_view, lux);
     main_view_set_EV(app->main_view, EV);

--- a/application/lightmeter_config.h
+++ b/application/lightmeter_config.h
@@ -1,15 +1,15 @@
 #pragma once
 
 #define LM_VERSION_APP "1.2"
-#define LM_DEVELOPED "Oleksii Kutuzov"
-#define LM_GITHUB "https://github.com/oleksiikutuzov/flipperzero-lightmeter"
+#define LM_DEVELOPED   "Oleksii Kutuzov"
+#define LM_GITHUB      "https://github.com/oleksiikutuzov/flipperzero-lightmeter"
 
-#define DOME_COEFFICIENT 2.3
-#define DEFAULT_ISO ISO_100
-#define DEFAULT_ND ND_0
-#define DEFAULT_APERTURE AP_2_8
-#define DEFAULT_SPEED SPEED_125
-#define DEFAULT_DOME WITHOUT_DOME
+#define DOME_COEFFICIENT  2.3
+#define DEFAULT_ISO       ISO_100
+#define DEFAULT_ND        ND_0
+#define DEFAULT_APERTURE  AP_2_8
+#define DEFAULT_SPEED     SPEED_125
+#define DEFAULT_DOME      WITHOUT_DOME
 #define DEFAULT_BACKLIGHT BACKLIGHT_AUTO
 
 typedef enum {
@@ -121,4 +121,7 @@ typedef enum {
     SENSOR_MAX44009,
 } LightMeterSensorType;
 
-typedef enum { BACKLIGHT_AUTO, BACKLIGHT_ON } LightMeterBacklight;
+typedef enum {
+    BACKLIGHT_AUTO,
+    BACKLIGHT_ON
+} LightMeterBacklight;

--- a/application/lightmeter_helper.c
+++ b/application/lightmeter_helper.c
@@ -1,11 +1,11 @@
 #include "lightmeter_helper.h"
-#include "lightmeter_config.h"
 
+extern const int iso_numbers[];
 extern const float aperture_numbers[];
 extern const float speed_numbers[];
 
-float lux2ev(float lux) {
-    return log2(lux / 2.5);
+float lux2ev(float lux, LightMeterISONumbers iso) {
+    return log2(lux / 2.5) + log2(iso_numbers[iso] / 100.0);
 }
 
 float getMinDistance(float x, float v1, float v2) {

--- a/application/lightmeter_helper.h
+++ b/application/lightmeter_helper.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include <math.h>
+#include <stdint.h>
 
-float lux2ev(float lux);
+#include "lightmeter_config.h"
+
+float lux2ev(float lux, LightMeterISONumbers iso);
 
 float getMinDistance(float x, float v1, float v2);
 


### PR DESCRIPTION
The current logic for computing the EV is correct, however, it only works for 100 ISO, therefore it might more accurately be called [LV / Light Value](https://en.wikipedia.org/wiki/Light_value) depending on who you ask:

> A synonym for "EV at ISO 100 [film speed](https://en.wikipedia.org/wiki/Film_speed)". This usage appears on many web pages, usually without attribution of an authoritative source. Eads (2000) proposed a revised [APEX](https://en.wikipedia.org/wiki/APEX_system) in which luminance value was equal to EV for ISO 100 speed, but he did not use the term light value.

Regardless, EV have a dependence on ISO, rather than just on Lux. The change in the PR adds the correct offset according to the formula from the Wikipedia page for [Exposure Values](https://en.wikipedia.org/wiki/Exposure_value):

> The exposure values in Table 2 are for ISO 100 speed ("EV100"). For a different ISO speed S, increase the exposure values (decrease the exposures) by the number of exposure steps by which that speed is greater than ISO 100, formally:
EVs = EV100 + log2(S / 100)